### PR TITLE
Update of FAB onPress

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -98,9 +98,9 @@ class _MyHomePageState extends State<MyHomePage> with SingleTickerProviderStateM
         animation: _animation,
 
         // On pressed change animation state
-        onPress: _animationController.isCompleted
-            ? _animationController.reverse
-            : _animationController.forward,
+        onPress: () => _animationController.isCompleted
+              ? _animationController.reverse()
+              : _animationController.forward(),
         
         // Floating Action button Icon color
         iconColor: Colors.blue,


### PR DESCRIPTION
Updated the example code that animates the FAB main button state. Previous code was not calling the reverse()- and forward()-methods, which made it impossible to close the FAB menu by clicking the FAB again.